### PR TITLE
LPD-15905 Upgrade deprecated actions to Node 20

### DIFF
--- a/.github/workflows/npmpublish.yaml
+++ b/.github/workflows/npmpublish.yaml
@@ -8,10 +8,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://npm.pkg.github.com/
           scope: '@leviy'
       - run: |


### PR DESCRIPTION
Actions using Node 16 are deprecated and should be updated to Node 20 actions.